### PR TITLE
remove global mode

### DIFF
--- a/KM4K.py
+++ b/KM4K.py
@@ -11,8 +11,6 @@ import rb303 as servo
 suica = nfc.clf.RemoteTarget("212F")
 suica.sensf_req = bytearray.fromhex("0000030000")
 
-mode = 2
-
 
 def sql_add(cur, name, idm):
     cur.execute("INSERT INTO users (name, idm) VALUES (?, ?)", (name, idm))
@@ -24,7 +22,6 @@ def sql_del(res):
 
 
 def add_nfc(cur):
-    assert mode == 0, "mode is not 0"
     name = input("name> ")
     print("Touch your Suica")
     idm = read_nfc()
@@ -39,7 +36,6 @@ def add_nfc(cur):
 
 
 def delete_nfc(cur):
-    assert mode == 1, "mode is not 1"
     name = input("name> ")
     cur.execute("SELECT * FROM users WHERE name=?", (name,))
     res = cur.fetchall()
@@ -101,9 +97,8 @@ def start_system(cur, isopen, okled_pin, ngled_pin):
                 time.sleep(1.7)
 
 
-
 def main(argv):
-    global mode
+    mode = 2
     dbname = "database.db"
     conn = sqlite3.connect(dbname)
     cur = conn.cursor()

--- a/test_KM4K.py
+++ b/test_KM4K.py
@@ -28,7 +28,6 @@ class TestKM4K(TestCase):
     def tearDown(self):
         self.conn.close()
 
-    @patch("KM4K.mode", 0)
     @patch("KM4K.input", return_value="kokentaro")
     @patch("KM4K.read_nfc", return_value=b"456789")
     def test_add_nfc_with_new_card(self, mocked_read_nfc, mocked_input):
@@ -46,7 +45,6 @@ class TestKM4K(TestCase):
         self.assertEqual(users[0]["idm"], b"456789")
         self.assertEqual(users[0]["date"], "2006/01/02 15:04:05")
 
-    @patch("KM4K.mode", 0)
     @patch("KM4K.input", return_value="kokentaro")
     @patch("KM4K.read_nfc", return_value=b"456789")
     def test_add_nfc_with_registered_card(self, mocked_read_nfc, mocked_input):
@@ -68,7 +66,6 @@ class TestKM4K(TestCase):
         self.assertEqual(users[0]["idm"], b"456789")
         self.assertEqual(users[0]["date"], "2006/01/02 15:04:05")
 
-    @patch("KM4K.mode", 1)
     @patch("KM4K.input", return_value="kokenjiro")
     def test_delete_nfc_with_registerd_user(self, mocked_input):
         self.cur.execute(
@@ -85,7 +82,6 @@ class TestKM4K(TestCase):
         users = self.cur.fetchall()
         self.assertEqual(len(users), 0)
 
-    @patch("KM4K.mode", 1)
     @patch("KM4K.input", return_value="kokenjiro")
     def test_delete_nfc_with_unregistered_user(self, mocked_input):
         from KM4K import delete_nfc
@@ -98,7 +94,6 @@ class TestKM4K(TestCase):
         users = self.cur.fetchall()
         self.assertEqual(len(users), 0)
 
-    @patch("KM4K.mode", 2)
     @patch("KM4K.servo", autospec=True)
     @patch("KM4K.read_nfc", side_effect=[b"345678", InterruptedError])
     def test_start_system_with_closed_door_and_registered_card(
@@ -118,7 +113,6 @@ class TestKM4K(TestCase):
         mocked_servo.open.assert_called_once()
         mocked_servo.lock.assert_not_called()
 
-    @patch("KM4K.mode", 2)
     @patch("KM4K.servo", autospec=True)
     @patch("KM4K.read_nfc", side_effect=[b"345678", InterruptedError])
     def test_start_system_with_closed_door_and_unregistered_card(
@@ -134,7 +128,6 @@ class TestKM4K(TestCase):
         mocked_servo.open.assert_not_called()
         mocked_servo.lock.assert_not_called()
 
-    @patch("KM4K.mode", 2)
     @patch("KM4K.servo", autospec=True)
     @patch("KM4K.read_nfc", side_effect=[b"345678", InterruptedError])
     def test_start_system_with_open_door_and_registered_card(
@@ -154,7 +147,6 @@ class TestKM4K(TestCase):
         mocked_servo.open.assert_not_called()
         mocked_servo.lock.assert_called_once()
 
-    @patch("KM4K.mode", 2)
     @patch("KM4K.servo", autospec=True)
     @patch("KM4K.read_nfc", side_effect=[b"345678", InterruptedError])
     def test_start_system_with_open_door_and_unregistered_card(


### PR DESCRIPTION
no need to depend on global `mode` variable because tests ensure correct behavior